### PR TITLE
Adding thread unit support to cores and thread unit shared attributes to registers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PAPER = irspec
 TEX = $(wildcard *.tex)
 BIB = refs.bib
 FIGS = $(wildcard figures/*.pdf figures/*.png figures/*.jpg ./*.jpg)
-VER = 1.0
+VER = 1.1
 
 .PHONY: all clean
 

--- a/irspec.lof
+++ b/irspec.lof
@@ -1,2 +1,2 @@
 \select@language {english}
-\contentsline {figure}{\numberline {1}{\ignorespaces CoreGen IR Node Hierarchy}}{8}{figure.1}
+\contentsline {figure}{\numberline {1}{\ignorespaces CoreGen IR Node Hierarchy}}{9}{figure.1}

--- a/irspec.lol
+++ b/irspec.lol
@@ -1,21 +1,21 @@
-\contentsline {lstlisting}{\numberline {1}Example IR YAML Indentation}{5}{lstlisting.1}
-\contentsline {lstlisting}{\numberline {2}Example IR Node Linkage}{5}{lstlisting.2}
-\contentsline {lstlisting}{\numberline {3}Sample Inline RTL}{10}{lstlisting.3}
-\contentsline {lstlisting}{\numberline {4}Sample External RTL File}{11}{lstlisting.4}
-\contentsline {lstlisting}{\numberline {5}Project Node Definition}{12}{lstlisting.5}
-\contentsline {lstlisting}{\numberline {6}Register Node Definition}{14}{lstlisting.6}
-\contentsline {lstlisting}{\numberline {7}Register Class Node Definition}{15}{lstlisting.7}
-\contentsline {lstlisting}{\numberline {8}Instruction Set Node Definition}{16}{lstlisting.8}
-\contentsline {lstlisting}{\numberline {9}Instruction Format Node Definition}{17}{lstlisting.9}
-\contentsline {lstlisting}{\numberline {10}Instruction Node Definition}{19}{lstlisting.10}
-\contentsline {lstlisting}{\numberline {11}Pseudo Instruction Node Definition}{20}{lstlisting.11}
-\contentsline {lstlisting}{\numberline {12}Cache Node Definition}{21}{lstlisting.12}
-\contentsline {lstlisting}{\numberline {13}Scratchpad Node Definition}{22}{lstlisting.13}
-\contentsline {lstlisting}{\numberline {14}VTP Node Definition}{23}{lstlisting.14}
-\contentsline {lstlisting}{\numberline {15}Memory Controller Node Definition}{24}{lstlisting.15}
-\contentsline {lstlisting}{\numberline {16}Communication Node Definition}{25}{lstlisting.16}
-\contentsline {lstlisting}{\numberline {17}Core Node Definition}{26}{lstlisting.17}
-\contentsline {lstlisting}{\numberline {18}SoC Node Definition}{27}{lstlisting.18}
-\contentsline {lstlisting}{\numberline {19}Extension Node Definition}{29}{lstlisting.19}
-\contentsline {lstlisting}{\numberline {20}Plugin Node Definition}{31}{lstlisting.20}
-\contentsline {lstlisting}{\numberline {21}Sample IR File}{33}{lstlisting.21}
+\contentsline {lstlisting}{\numberline {1}Example IR YAML Indentation}{6}{lstlisting.1}
+\contentsline {lstlisting}{\numberline {2}Example IR Node Linkage}{6}{lstlisting.2}
+\contentsline {lstlisting}{\numberline {3}Sample Inline RTL}{11}{lstlisting.3}
+\contentsline {lstlisting}{\numberline {4}Sample External RTL File}{12}{lstlisting.4}
+\contentsline {lstlisting}{\numberline {5}Project Node Definition}{13}{lstlisting.5}
+\contentsline {lstlisting}{\numberline {6}Register Node Definition}{15}{lstlisting.6}
+\contentsline {lstlisting}{\numberline {7}Register Class Node Definition}{16}{lstlisting.7}
+\contentsline {lstlisting}{\numberline {8}Instruction Set Node Definition}{17}{lstlisting.8}
+\contentsline {lstlisting}{\numberline {9}Instruction Format Node Definition}{18}{lstlisting.9}
+\contentsline {lstlisting}{\numberline {10}Instruction Node Definition}{20}{lstlisting.10}
+\contentsline {lstlisting}{\numberline {11}Pseudo Instruction Node Definition}{21}{lstlisting.11}
+\contentsline {lstlisting}{\numberline {12}Cache Node Definition}{22}{lstlisting.12}
+\contentsline {lstlisting}{\numberline {13}Scratchpad Node Definition}{23}{lstlisting.13}
+\contentsline {lstlisting}{\numberline {14}VTP Node Definition}{24}{lstlisting.14}
+\contentsline {lstlisting}{\numberline {15}Memory Controller Node Definition}{25}{lstlisting.15}
+\contentsline {lstlisting}{\numberline {16}Communication Node Definition}{26}{lstlisting.16}
+\contentsline {lstlisting}{\numberline {17}Core Node Definition}{27}{lstlisting.17}
+\contentsline {lstlisting}{\numberline {18}SoC Node Definition}{28}{lstlisting.18}
+\contentsline {lstlisting}{\numberline {19}Extension Node Definition}{30}{lstlisting.19}
+\contentsline {lstlisting}{\numberline {20}Plugin Node Definition}{32}{lstlisting.20}
+\contentsline {lstlisting}{\numberline {21}Sample IR File}{34}{lstlisting.21}

--- a/irspec.lot
+++ b/irspec.lot
@@ -1,8 +1,8 @@
 \select@language {english}
-\contentsline {table}{\numberline {1}{\ignorespaces CoreGen IR Scalar Types}}{10}{table.1}
-\contentsline {table}{\numberline {2}{\ignorespaces CoreGen Project Types}}{12}{table.2}
-\contentsline {table}{\numberline {3}{\ignorespaces CoreGen Register Node Parameters}}{13}{table.3}
-\contentsline {table}{\numberline {4}{\ignorespaces CoreGen Instruction Format Node Parameters}}{17}{table.4}
-\contentsline {table}{\numberline {5}{\ignorespaces CoreGen Instruction Format Node Parameters}}{25}{table.5}
-\contentsline {table}{\numberline {6}{\ignorespaces CoreGen Plugin Node Parameters}}{30}{table.6}
-\contentsline {table}{\numberline {7}{\ignorespaces CoreGen Plugin Node Feature Types}}{31}{table.7}
+\contentsline {table}{\numberline {2}{\ignorespaces CoreGen IR Scalar Types}}{11}{table.2}
+\contentsline {table}{\numberline {3}{\ignorespaces CoreGen Project Types}}{13}{table.3}
+\contentsline {table}{\numberline {4}{\ignorespaces CoreGen Register Node Parameters}}{14}{table.4}
+\contentsline {table}{\numberline {5}{\ignorespaces CoreGen Instruction Format Node Parameters}}{18}{table.5}
+\contentsline {table}{\numberline {6}{\ignorespaces CoreGen Instruction Format Node Parameters}}{26}{table.6}
+\contentsline {table}{\numberline {7}{\ignorespaces CoreGen Plugin Node Parameters}}{31}{table.7}
+\contentsline {table}{\numberline {8}{\ignorespaces CoreGen Plugin Node Feature Types}}{32}{table.8}

--- a/irspec.tex
+++ b/irspec.tex
@@ -33,6 +33,7 @@
 \usepackage{dirtree}
 \usepackage{multirow}
 \usepackage{draftwatermark} % required for watermarks
+\usepackage{vhistory}
 \RequirePackage{epstopdf}
 \RequirePackage{tabularx}
 \RequirePackage{xstring}
@@ -77,10 +78,10 @@
 %----------------------------------------------------------------------------------------
 \pagestyle{fancy}
 \lhead{}
-\chead{\textbf{CoreGen IR Spec v.1.0}}  % -- classification
+\chead{\textbf{CoreGen IR Spec v.1.1}}  % -- classification
 \rhead{}
 \lfoot{} %-- format: TR YYYY-RRR-V.V; y = year; r = report; v = version
-\cfoot{\textbf{CoreGen IR Spec v.1.0}}  % -- classification
+\cfoot{\textbf{CoreGen IR Spec v.1.1}}  % -- classification
 \rfoot{\thepage}      % -- page number
 
 %----------------------------------------------------------------------------------------
@@ -108,8 +109,8 @@
 
 \begin{center}
 \begin{tabular}{l r}
-Date: & September 12, 2018 \\ % Date the experiment was performed
-Revision: & 1.0 \\         % revision number
+Date: & November 21, 2018 \\ % Date the experiment was performed
+Revision: & 1.1 \\         % revision number
 Authors: & Tactical Computing Labs\\ % Author names
 & contact@tactcomplabs.com\\
 \end{tabular}
@@ -129,7 +130,7 @@ Authors: & Tactical Computing Labs\\ % Author names
 \clearpage
 
 %----------------------------------------------------------------------------------------
-%       List of Figures
+%       List of Document Elements
 %----------------------------------------------------------------------------------------
 
 \clearpage
@@ -137,6 +138,18 @@ Authors: & Tactical Computing Labs\\ % Author names
 \lstlistoflistings
 \listoftables
 %\listofalgorithms
+\clearpage
+
+%----------------------------------------------------------------------------------------
+%       Changelog
+%----------------------------------------------------------------------------------------
+
+\clearpage
+\begin{versionhistory}
+  \vhEntry{1.0}{09.12.2018}{JLeidel}{Initial public release}
+  \vhEntry{1.1}{11.21.2018}{JLeidel}{Adding ThreadUnits to Core nodes}
+\end{versionhistory}
+
 \clearpage
 
 %----------------------------------------------------------------------------------------
@@ -955,13 +968,23 @@ performance of the core will be very poor.
 
 In addition to the aforementioned base nodes, cores can be augmented with one or more extensions.  These extensions 
 may include additional, registers, register classes or other non-standard nodes beyond what is defined in the base 
-core infrastructure.  We see an example of a basic and extended core node in Listing~\ref{lis:core}.   
+core infrastructure.
+
+Core nodes may also define the degree of symmetric multithreading (SMT) by specifying the number of \texttt{ThreadUnits}.  
+This optional keyword permits users to specify the number of unique thread units for the respective core.  The hardware 
+code generator will output unique register files for each thread unit unless a register has been designated as \texttt{Shared}.  
+The code generator will not, however, output unique \texttt{Extensions} for each thread unit.  
+A single instance of a shared register will be generated and shared across the cores.  If not specified, the number of 
+\texttt{ThreadUnits} is assumed to be \textit{1}.  
+
+We see an example of a basic and extended core node in Listing~\ref{lis:core}.   
 
 \vspace{0.125in}
 \begin{lstlisting}[frame=single,style=base,caption={Core Node Definition},captionpos=b,label={lis:core}]
 - Core: @String@
     Cache: @String@
     ISA: @String@
+    ThreadUnits: @2@
     RegisterClasses:
       - RegClass: @String@
       - RegClass: @String@

--- a/irspec.tex
+++ b/irspec.tex
@@ -147,7 +147,7 @@ Authors: & Tactical Computing Labs\\ % Author names
 \clearpage
 \begin{versionhistory}
   \vhEntry{1.0}{09.12.2018}{JLeidel}{Initial public release}
-  \vhEntry{1.1}{11.21.2018}{JLeidel}{Adding ThreadUnits to Core nodes}
+  \vhEntry{1.1}{11.21.2018}{JLeidel}{Adding ThreadUnits to Core nodes and TUSReg register attributes}
 \end{versionhistory}
 
 \clearpage
@@ -542,6 +542,9 @@ to as a \texttt{PseudoName}.  Additional parameters are described in Table~\ref{
 \multirow{2}{*}{\texttt{AMSReg}} & Sets a parameter indicating that the register is an arithmetic machine state register.\\
                                                           & The hardware code generator will integrate these into the pipeline. (Bool)\\
 \hline
+\multirow{2}{*}{\texttt{TUSReg}} & Sets a parameter indicating that the register is shared across all thread units within the core.\\
+                                                          & Either \texttt{Shared} or \texttt{TUSReg} can be set, but not both. (Bool)\\
+\hline
 \multirow{2}{*}{\texttt{Shared}} & Sets a parameter indicating that the register is a shared register.\\
                                                           & The hardware generator will create \textbf{ONE} instance of the register for all cores. (Bool)\\
 \hline
@@ -563,6 +566,7 @@ Registers:
     ROReg: @Bool@
     CSRReg: @Bool@
     AMSReg: @Bool@
+    TUSReg: @Bool@
     Shared: @Bool@
   - RegName: @String@
     Width: @Integer@
@@ -574,6 +578,7 @@ Registers:
     ROReg: @Bool@
     CSRReg: @Bool@
     AMSReg: @Bool@
+    TUSReg: @Bool@
     Shared: @Bool@
    ...more registers
 \end{lstlisting}  
@@ -972,7 +977,9 @@ core infrastructure.
 
 Core nodes may also define the degree of symmetric multithreading (SMT) by specifying the number of \texttt{ThreadUnits}.  
 This optional keyword permits users to specify the number of unique thread units for the respective core.  The hardware 
-code generator will output unique register files for each thread unit unless a register has been designated as \texttt{Shared}.  
+code generator will output unique register files for each thread unit unless a register has been designated as 
+\textit{thread unit shared} (\texttt{TUSReg}) or \texttt{Shared}.  See Section~\ref{sec:RegisterNodes} for descriptions 
+of these register attributes.    
 The code generator will not, however, output unique \texttt{Extensions} for each thread unit.  
 A single instance of a shared register will be generated and shared across the cores.  If not specified, the number of 
 \texttt{ThreadUnits} is assumed to be \textit{1}.  


### PR DESCRIPTION
Adding thread unit support to cores and thread unit shared attributes to registers
Does not add any additional IR nodes.  Existing nodes contain the new attributes. 